### PR TITLE
cargo: use streams develop branch, do not use iota-core explicitly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,7 @@ path = "src/lib.rs"
 [dependencies]
 failure = "0.1.7"
 anyhow = { version = "1.0", default-features = false }
-iota-streams = { git = "https://github.com/iotaledger/streams", rev = "456347a"}
-iota-core = { git = "https://github.com/iotaledger/iota.rs", rev = "74fa529" }
+iota-streams = { git = "https://github.com/iotaledger/streams", branch = "develop" }
 serde = {version="1.0.110", features = ["derive"] }
 serde_derive = "1.0.110"
 serde_json = "1.0.53"

--- a/src/streams_subscriber/subscriber.rs
+++ b/src/streams_subscriber/subscriber.rs
@@ -4,7 +4,7 @@
 use crate::streams_subscriber::random_seed;
 
 use iota_streams::app::transport::tangle::{
-    client::{Client, SendTrytesOptions},
+    client::Client,
     PAYLOAD_BYTES,
 };
 use iota_streams::app_channels::api::tangle::{Address, Subscriber};
@@ -37,15 +37,7 @@ impl Channel {
             Some(seed) => seed,
             None => random_seed(),
         };
-        let send_opt = SendTrytesOptions::default();
-        let client: Client = Client::new(
-            send_opt,
-            iota::client::ClientBuilder::new()
-                .node(&node)
-                .unwrap()
-                .build()
-                .unwrap(),
-        );
+        let client: Client = Client::new_from_url(&node);
         let subscriber = Subscriber::new(&seed, "utf-8", PAYLOAD_BYTES, client);
 
         Self {


### PR DESCRIPTION
A follow up for https://github.com/iot2tangle/streams-gateway-core/pull/5